### PR TITLE
For recorded mp4 data, use -delay to decide gap between frames

### DIFF
--- a/src/configure.py
+++ b/src/configure.py
@@ -92,11 +92,10 @@ class ExecuteBase:
     def _set_image_sample_from_stream(self, target_frame):
         for frame, sample in enumerate(self.camera_device.get_stream()):
             if frame == target_frame:
-                print(f"Found our frame: {frame}")
                 image = sample.data
                 timestamp = sample.timestamp
-                return sample,image,timestamp
-        raise Exception(f"Could not find frame {target_frame}")
+                return sample, image, timestamp
+        raise Exception(f"Couldnt find frame {target_frame}")
 
     def set_images(self):
         self.current_sample,self.current_image,self.current_timestamp = self._set_image_sample()
@@ -104,37 +103,15 @@ class ExecuteBase:
             self.next_sample,self.next_image,self.next_timestamp = None,None,None
         elif self.MODEL_TYPE == 'smokeynet':
             if isinstance(self.camera_device, RecordedMP4):
-                self.next_sample,self.next_image,self.next_timestamp = self._set_image_sample_from_stream(self.smokey_net_delay)
+                self.next_sample, self.next_image, self.next_timestamp = \
+                    self._set_image_sample_from_stream(self.smokey_net_delay)
             else:
                 sleep(self.smokey_net_delay)
                 self.next_sample,self.next_image,self.next_timestamp = self._set_image_sample()
-            # tuna
-            #frame, frame_of_interest = 0, 50
-            #for frame, sample in enumerate(self.camera_device._camera.stream()):
-            #    self.next_sample = sample
-            #    self.next_image = sample.data
-            #    self.next_timestamp = sample.timestamp
-            #    print(f"Frame {frame:02}")
-            #    # if frame >= frame_of_interest:
-            #    #     print(f"Found our frame: {frame:02}")
-            #    #     break
-                
 
-    
     def run(self,smoke_threshold):
         self.set_images()
-
-        print("Writing to disk")
-        self.current_sample.save("sample_current.jpg")
-        self.next_sample.save("sample_next.jpg")
-        print("current_image", self.current_image.shape)
-        print("next_image", self.next_image.shape)
-
         current_image = self.current_image
         next_image = self.next_image
         self.inference_results = self._model_obj.inference(next_image,current_image,smoke_threshold)
-        image_preds, tile_preds, tile_probs = self.inference_results
-        print("image_preds:", image_preds)
-        print("tile_preds:", tile_preds)
-        print("tile_probs:", tile_probs)
         

--- a/src/configure.py
+++ b/src/configure.py
@@ -36,6 +36,9 @@ class CameraDeviceBase(CameraDeviceInterface):
     def get_sample(self):
         return self._camera.snapshot()
 
+    def get_stream(self):
+        return self._camera.stream()
+
 class RecordedMP4(CameraDeviceBase):
     def __init__(self):
         self.sample_mp4 = '20190610-Pauma-bh-w-mobo-c.mp4'
@@ -86,16 +89,52 @@ class ExecuteBase:
         timestamp = sample.timestamp
         return sample,image,timestamp
 
+    def _set_image_sample_from_stream(self, target_frame):
+        for frame, sample in enumerate(self.camera_device.get_stream()):
+            if frame == target_frame:
+                print(f"Found our frame: {frame}")
+                image = sample.data
+                timestamp = sample.timestamp
+                return sample,image,timestamp
+        raise Exception(f"Could not find frame {target_frame}")
+
     def set_images(self):
         self.current_sample,self.current_image,self.current_timestamp = self._set_image_sample()
         if self.MODEL_TYPE == 'binary-classifier':
             self.next_sample,self.next_image,self.next_timestamp = None,None,None
         elif self.MODEL_TYPE == 'smokeynet':
-            sleep(self.smokey_net_delay)
-            self.next_sample,self.next_image,self.next_timestamp = self._set_image_sample()
+            if isinstance(self.camera_device, RecordedMP4):
+                self.next_sample,self.next_image,self.next_timestamp = self._set_image_sample_from_stream(self.smokey_net_delay)
+            else:
+                sleep(self.smokey_net_delay)
+                self.next_sample,self.next_image,self.next_timestamp = self._set_image_sample()
+            # tuna
+            #frame, frame_of_interest = 0, 50
+            #for frame, sample in enumerate(self.camera_device._camera.stream()):
+            #    self.next_sample = sample
+            #    self.next_image = sample.data
+            #    self.next_timestamp = sample.timestamp
+            #    print(f"Frame {frame:02}")
+            #    # if frame >= frame_of_interest:
+            #    #     print(f"Found our frame: {frame:02}")
+            #    #     break
+                
+
     
     def run(self,smoke_threshold):
         self.set_images()
+
+        print("Writing to disk")
+        self.current_sample.save("sample_current.jpg")
+        self.next_sample.save("sample_next.jpg")
+        print("current_image", self.current_image.shape)
+        print("next_image", self.next_image.shape)
+
         current_image = self.current_image
         next_image = self.next_image
         self.inference_results = self._model_obj.inference(next_image,current_image,smoke_threshold)
+        image_preds, tile_preds, tile_probs = self.inference_results
+        print("image_preds:", image_preds)
+        print("tile_preds:", tile_preds)
+        print("tile_probs:", tile_probs)
+        

--- a/src/configure.py
+++ b/src/configure.py
@@ -114,4 +114,3 @@ class ExecuteBase:
         current_image = self.current_image
         next_image = self.next_image
         self.inference_results = self._model_obj.inference(next_image,current_image,smoke_threshold)
-        

--- a/src/main.py
+++ b/src/main.py
@@ -53,7 +53,7 @@ parser.add_argument('-delay',
                         metavar='smokeynet_delay',
                         type=float,
                         default=60.0,
-                        help='SmokeyNet time delay to get the next image from Camera (seconds). Default is set to 60 secs due to HPWREN FigLib Trainning Data'
+                        help='SmokeyNet delay to get the next image from Camera. (seconds) for real-time video and (frames) for recorded video. Default is set to 60 due to HPWREN FigLib Trainning Data'
                     )
 
 parser.add_argument('-sdt',
@@ -133,4 +133,4 @@ execute.run(smoke_threshold)
 
 logging.info('Publish')
 publisher_waggle = publisher.PublisherWaggle(model_type,execute)
-publisher_waggle.publish(sage_data_topic,smoke_threshold,camera_src)
+# publisher_waggle.publish(sage_data_topic,smoke_threshold,camera_src)

--- a/src/main.py
+++ b/src/main.py
@@ -133,4 +133,4 @@ execute.run(smoke_threshold)
 
 logging.info('Publish')
 publisher_waggle = publisher.PublisherWaggle(model_type,execute)
-# publisher_waggle.publish(sage_data_topic,smoke_threshold,camera_src)
+publisher_waggle.publish(sage_data_topic,smoke_threshold,camera_src)


### PR DESCRIPTION
Hi @iperezx! Here's a PR which allows a RecordedMP4 to get a specific frame for SmokeyNet, instead of always the first frame. I thought it was logical to repackage the `-delay` arg to mean a delay in frames when recorded video is being used.